### PR TITLE
33 docs dbt

### DIFF
--- a/docs/documentacao/tutoriais/dbt/arquitetura-medallion.md
+++ b/docs/documentacao/tutoriais/dbt/arquitetura-medallion.md
@@ -1,12 +1,105 @@
 # Arquitetura e Modelagem de Dados
 
-A modelagem de dados e a organização dos esquemas devem seguir a arquitetura em camadas definida para o repositório, baseada nos estágios de maturidade e tratamento dos dados. Esta abordagem facilita a rastreabilidade, o controle de qualidade e a evolução gradual dos dados ao longo do tempo. As camadas estão estruturadas da seguinte forma:
+A organização dos dados no repositório segue a **arquitetura em camadas (medalhão)**, alinhada às práticas modernas de engenharia de dados e ao uso do **dbt (Data Build Tool)** para transformação e modelagem.
 
-- **Raw**: camada bruta, que armazena os dados exatamente como foram recebidos da fonte, sem qualquer transformação. Serve como fonte de verdade e histórico imutável.
-- **Bronze**: camada de dados limpos e estruturados de forma padronizada, com correções mínimas (como tipos de dados e normalização básica), mantendo a granularidade original.
-- **Silver**: camada onde os dados passam por enriquecimentos, junções e integrações entre diferentes fontes, além de validações mais complexas.
-- **Gold**: camada final, otimizada para consumo e análise. Contém métricas, agregações e tabelas derivadas voltadas a casos de uso específicos, como dashboards, relatórios e serviços.
+Essa abordagem facilita a rastreabilidade, o controle de qualidade, a documentação e a evolução gradual dos dados ao longo do tempo, permitindo que cada etapa do pipeline seja **clara, modular e auditável**.
 
-Ao propor modificações ou novos pipelines, certifique-se de posicionar corretamente os dados dentro dessa estrutura e seguir os padrões de nomenclatura, versionamento e particionamento definidos. Alterações em qualquer uma dessas camadas devem ser devidamente documentadas e revisadas pelo time responsável, garantindo consistência e rastreabilidade.
+As camadas estão estruturadas da seguinte forma:
 
-Essa organização em camadas é fundamental para garantir qualidade, confiabilidade e governança sobre os dados tratados no repositório.
+---
+
+### **Raw**
+
+* **Descrição:** camada bruta que armazena os dados exatamente como foram recebidos da fonte (APIs, arquivos, sistemas transacionais, etc.), sem qualquer transformação.
+* **Objetivo:** atuar como **fonte de verdade** e manter um histórico imutável, preservando o dado original.
+* **Uso no dbt:** os dados da camada *raw* são referenciados no dbt através de `source()`, garantindo rastreabilidade desde a origem.
+
+Exemplo:
+
+```sql
+select * from {{ source('transfere_gov', 'contratos') }}
+```
+
+---
+
+### **Bronze**
+
+* **Descrição:** camada de padronização, onde os dados passam por correções mínimas (ajuste de tipos, normalização de colunas, limpeza básica).
+* **Objetivo:** estruturar os dados de forma consistente, mantendo a granularidade original.
+* **Uso no dbt:** modelos bronze geralmente são **incrementais**, garantindo ingestão eficiente de grandes volumes sem recriar toda a tabela a cada execução.
+
+Exemplo:
+
+```sql
+select
+    cast(id_contrato as integer) as id_contrato,
+    upper(empresa_nome) as empresa_nome,
+    valor
+from {{ source('transfere_gov', 'contratos') }}
+```
+
+---
+
+### **Silver**
+
+* **Descrição:** camada de integração e enriquecimento.
+  Aqui os dados passam por **junções entre diferentes fontes**, cálculos derivados, regras de negócio e validações mais complexas.
+* **Objetivo:** consolidar informações, criando tabelas prontas para análise integrada.
+* **Uso no dbt:** modelos silver frequentemente utilizam `ref()` para **referenciar diretamente os modelos bronze**, garantindo modularidade e lineage automático.
+
+Exemplo:
+
+```sql
+select
+    c.id_contrato,
+    c.empresa_nome,
+    e.valor_empenho
+from {{ ref('contratos_bronze') }} c
+left join {{ ref('empenhos_bronze') }} e 
+    on c.id_contrato = e.contrato_id
+```
+
+---
+
+### **Gold**
+
+* **Descrição:** camada final, otimizada para **consumo analítico**.
+  Aqui estão as tabelas agregadas, métricas, indicadores e visões específicas para **dashboards, relatórios e APIs**.
+* **Objetivo:** fornecer dados confiáveis e prontos para negócio, com **granularidade reduzida e performance otimizada**.
+* **Uso no dbt:** modelos gold costumam ser **tables materializadas**, garantindo consultas rápidas para ferramentas de BI (Superset, Power BI, Metabase).
+
+Exemplo:
+
+```sql
+select
+    empresa_nome,
+    count(distinct id_contrato) as qtd_contratos,
+    sum(valor_empenho) as total_empenhado
+from {{ ref('contratos_integrados_silver') }}
+group by empresa_nome
+```
+
+---
+
+## Boas práticas na Arquitetura Medalhão com dbt
+
+1. **Separação clara por pastas:** `models/bronze`, `models/silver`, `models/gold`.
+2. **Nomenclatura padronizada:** use sufixos ou prefixos que indiquem a camada (ex: `contratos_bronze`, `contratos_silver`).
+3. **Documentação e testes:** cada camada deve ser descrita em arquivos `.yml` com seus campos, e validada com testes (`not_null`, `unique`, `relationships`).
+4. **Controle de materialização:**
+
+    * *Raw* = apenas referência (source).
+    * *Bronze* = incremental ou tabela.
+    * *Silver* = tabela.
+    * *Gold* = tabela persistente.
+
+
+5. **Governança e rastreabilidade:** toda alteração em uma camada deve ser registrada, documentada e revisada, garantindo consistência do pipeline.
+
+---
+
+A arquitetura medalhão, implementada com o dbt, permite criar pipelines de dados **claros, auditáveis e escaláveis**.
+Cada camada tem um papel específico e, ao usar `source()` e `ref()`, conseguimos **manter rastreabilidade ponta a ponta**: desde a entrada bruta até as métricas finais consumidas pelos usuários de negócio.
+
+Essa estrutura é essencial para garantir **qualidade, confiabilidade e governança** sobre os dados tratados no repositório.
+

--- a/docs/documentacao/tutoriais/dbt/modelos.md
+++ b/docs/documentacao/tutoriais/dbt/modelos.md
@@ -1,21 +1,32 @@
 # O que são modelos DBT?
 
-Arquivos SQL para manipulação e criação de tabelas referenciáveis e reutilizáveis.
+No **dbt (Data Build Tool)**, os **modelos** são arquivos SQL que definem como os dados devem ser transformados e estruturados.
+Cada modelo gera uma tabela, view ou outro objeto no banco de dados, e pode ser **referenciado** e **reutilizado** em outras partes do projeto.
 
-## Configurando dbt_project.yml
-O arquivo `dbt_project.yml` é o principal arquivo de configuração de um projeto DBT. Nele, você define informações essenciais como o nome do projeto, diretórios de modelos, configurações de materialização padrão, variáveis, configurações de perfil de conexão e outras opções que controlam o comportamento do DBT.
+Essa abordagem permite organizar as transformações de forma modular, rastreável e escalável, garantindo qualidade e governança no pipeline de dados.
 
-Exemplo de `dbt_project.yml` usado no projeto com o IPEA:
+---
+
+## Estrutura do `dbt_project.yml`
+
+O arquivo `dbt_project.yml` é o **coração do projeto dbt**. Ele centraliza as configurações, como:
+
+* Nome e versão do projeto
+* Caminhos para modelos, macros, testes, seeds etc.
+* Configurações padrão de materialização (tabelas, views, incrementais)
+* Perfis de conexão com o banco de dados
+* Ações automáticas antes ou depois de rodar os modelos
+
+### Exemplo usado no projeto IPEA:
 
 ```yaml
 name: 'ipea'
-
 version: 1.0.0
 config-version: 2
 
 profile: ipea
 
-# Definindo o caminho para algumas das funcionalidades
+# Caminhos para os artefatos do projeto
 model-paths: ["models"]
 analysis-paths: ["analyses"]
 test-paths: ["tests"]
@@ -23,13 +34,13 @@ seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
 
+# Pastas que podem ser limpas com dbt clean
 clean-targets:
   - "target"
   - "dbt_packages"
   - "logs"
 
-# Aqui define-se onde e como os modelos serão organizados, 
-# assim como configurações padrão de meterialização
+# Configuração dos modelos
 models:
   ipea: 
     +database: analytics
@@ -51,61 +62,207 @@ models:
       views:
         +materialized: view
 
-# Essa configuração define a macro que será executada 
-# antes de cada modelos para criar as UDFs
+# Macro executada antes de rodar os modelos
 on-run-start:
-  - '{{create_udfs()}}'
+  - '{{ create_udfs() }}'
 ```
 
-Esse arquivo garante que o DBT saiba onde encontrar os modelos, como executá-los e quais padrões aplicar durante o build do projeto.
+Esse arquivo garante que o dbt saiba **onde encontrar os modelos, como executá-los e quais padrões aplicar** durante o build.
 
-## Referenciando um modelo
+---
 
-A dependência entre modelos é feita usando a sintaxe
+## Referenciando modelos
+
+Uma das maiores forças do dbt é a **gestão automática de dependências entre modelos**.
+Em vez de escrever subqueries gigantes ou referenciar diretamente tabelas do banco, usamos o macro `ref()`.
+
+O dbt entende essas referências e monta o **grafo de dependência**: ele sabe a ordem correta de execução dos modelos e garante que cada transformação só rode depois de suas dependências estarem prontas.
+
+
+### Sem dbt (SQL tradicional)
+
+No SQL puro, é comum encadear transformações usando **subqueries** ou **CTEs**.
+Por exemplo, para calcular a média de contratos ativos, teríamos algo assim:
+
+```sql
+create table contratos_ativos_media as
+select 
+    empresa_id,
+    avg(valor) as media_valor
+from (
+    select
+        id_contrato,
+        empresa_id,
+        valor,
+        status
+    from contratos_raw
+    where status = 'ativo'
+) as contratos_filtrados
+group by empresa_id;
+```
+
+Nesse caso, toda a lógica fica embutida em uma única query.
+Se precisarmos reutilizar a parte intermediária (`contratos_filtrados`), teremos que copiar e colar a subquery em outros lugares.
+
+---
+
+### Com dbt (usando `ref()`)
+
+No dbt, quebramos as transformações em **modelos organizados em pastas (bronze, silver, gold)**.
+Cada etapa fica em um arquivo separado e podemos **referenciar modelos anteriores** com `ref()`:
+
+#### 1. Modelo Bronze (`models/bronze/contratos_base.sql`)
 
 ```sql
 select
-    ...
-from {{ ref('<nome_do_modelo>') }}
+    id_contrato,
+    empresa_id,
+    valor,
+    status
+from {{ source('sistema_legado', 'contratos_raw') }}
 ```
 
-após o `dbt build`, essa query é compilada em
+---
+
+#### 2. Modelo Silver (`models/silver/contratos_filtrados.sql`)
 
 ```sql
 select
-    ...
-from schema.nome_do_modelo
+    id_contrato,
+    empresa_id,
+    valor
+from {{ ref('contratos_base') }}
+where status = 'ativo'
 ```
 
-caso o modelo seja realocado para outro esquema, no momento da compilação a referência se adapta à mudança automaticamente
+---
 
-## Sources
-
-Quando uma tabela possui origem que não seja através de um modelo dbt, usa-se `source` para referenciá-las
+#### 3. Modelo Gold (`models/gold/contratos_ativos_media.sql`)
 
 ```sql
 select 
-    ...
+    empresa_id,
+    avg(valor) as media_valor
+from {{ ref('contratos_filtrados') }}
+group by empresa_id
+```
+
+---
+
+### Benefícios práticos do `ref()`
+
+1. **Independência do schema/nome físico:** você escreve `ref('contratos_base')` e o dbt resolve para o schema/tabela corretos na compilação.
+2. **Grafo de execução automático:** o dbt entende que `contratos_ativos_media` depende de `contratos_filtrados`, que depende de `contratos_base`.
+3. **Documentação e lineage:** ao gerar a documentação (`dbt docs generate`), você visualiza o fluxo completo (bronze → silver → gold).
+4. **Reuso e modularidade:** cada transformação pode ser reutilizada em outros modelos sem duplicar código.
+
+
+Resumindo: no SQL tradicional você teria queries longas com subqueries duplicadas; já no dbt, você ganha **modularidade, rastreabilidade e consistência** só organizando os modelos e usando `ref()`.
+
+---
+
+## Trabalhando com Sources
+
+
+Em muitos projetos de dados, começamos a trabalhar a partir de **tabelas brutas** vindas de sistemas transacionais, APIs ou arquivos que foram carregados para o banco (camada **raw**).
+Essas tabelas não foram criadas pelo dbt, mas são a **matéria-prima** para nossas transformações.
+
+Para lidar com elas de forma organizada, o dbt oferece o conceito de **sources**.
+Um `source` é uma referência declarada a uma tabela externa, que permite:
+
+* **Manter rastreabilidade:** você sabe de onde o dado realmente veio.
+* **Evitar hardcode de nomes e schemas:** assim como `ref()`, o `source()` resolve automaticamente o schema e a tabela correta.
+* **Documentar a origem dos dados:** os sources aparecem no lineage e na documentação do dbt.
+* **Testar qualidade na camada raw:** você pode aplicar testes (ex: `not_null`, `unique`) diretamente nos sources.
+
+---
+
+### Exemplo de uso do `source()`
+
+```sql
+select 
+    id_contrato,
+    empresa_id,
+    valor,
+    data_assinatura
 from {{ source('transfere_gov', 'contratos') }}
 ```
 
-## Tipos de modelos
+Aqui, `transfere_gov` é o **nome da source** (geralmente definido em um arquivo `sources.yml`) e `contratos` é a tabela bruta dentro desse schema.
+Na compilação, isso pode virar algo como:
 
-No DBT,  os modelos possuem diferentes tipos de materialização, que servem propósitos específicos:
+```sql
+select 
+    id_contrato,
+    empresa_id,
+    valor,
+    data_assinatura
+from transfere_gov.contratos
+```
 
-- **Table:** Cria uma tabela física persistente que é reconstruída a cada execução
-- **View:** Cria uma view SQL que é reconstruída a cada consulta
-- **Incremental:** Atualiza apenas os registros novos ou modificados, ideal para grandes conjuntos de dados
-- **Ephemeral:** Não cria objeto no banco, funciona como CTE (Common Table Expression) em outros modelos
+---
 
-Cada tipo de materialização tem seu caso de uso específico, dependendo das necessidades de performance, volume de dados e frequência de atualização.
+### Como os sources se conectam ao dbt
 
-## Boas práticas
+Para declarar um source, usamos um arquivo YAML (ex: `models/sources.yml`):
 
-- Utilizar nomenclatura clara e consistente
-- Documentar todos os modelos e suas transformações
-- Implementar testes para validar a qualidade dos dados
-- Manter o código modular e reutilizável
-- Versionar os modelos usando controle de código
+```yaml
+version: 2
 
-Com DBT, as equipes de dados podem construir transformações confiáveis e escaláveis, facilitando a manutenção e evolução do pipeline de dados analíticos.
+sources:
+  - name: transfere_gov
+    schema: raw
+    tables:
+      - name: contratos
+      - name: empenhos
+```
+
+Isso informa ao dbt que existe um schema chamado `raw` com as tabelas `contratos` e `empenhos`.
+Agora, sempre que precisarmos usar esses dados brutos, referenciamos via `{{ source('transfere_gov', 'contratos') }}` em vez de escrever `raw.contratos`.
+
+---
+
+### Importância prática dos sources
+
+* **Camada raw como contrato estável:** o dbt enxerga a camada bruta como o ponto de partida confiável para todas as transformações.
+* **Separação clara de responsabilidades:** tudo que é “de fora” fica documentado como source; tudo que é “produzido dentro do projeto” é model.
+* **Visibilidade do lineage:** na documentação interativa, você consegue ver graficamente quais modelos dependem de quais tabelas brutas.
+* **Validação desde a origem:** garante que problemas (como nulos, duplicados ou chaves quebradas) sejam identificados antes mesmo de chegar nas camadas silver/gold.
+
+---
+
+Em resumo: os **sources** são a ponte entre a **camada raw** (dados crus) e os **modelos dbt** (transformações). Eles garantem rastreabilidade, qualidade e organização do pipeline de ponta a ponta.
+
+---
+
+
+## Tipos de Materialização
+
+O dbt permite controlar como cada modelo será materializado:
+
+* **Table:** Cria uma tabela física persistente, substituída a cada execução.
+* **View:** Cria uma view SQL, atualizada em tempo de consulta.
+* **Incremental:** Atualiza apenas novos ou modificados, ideal para grandes volumes.
+* **Ephemeral:** Não cria objeto no banco, funciona como uma CTE dentro de outros modelos.
+
+Cada tipo tem um caso de uso específico, balanceando **performance, custo e necessidade de atualização**.
+
+---
+
+## Boas práticas no uso do dbt
+
+* **Nomenclatura consistente:** facilita leitura e manutenção.
+* **Documentação clara:** cada modelo deve ter descrição no `.yml`.
+* **Testes automáticos:** validar integridade (`not_null`, `unique`, `relationships`) e qualidade.
+* **Modularidade:** dividir transformações em etapas pequenas e reutilizáveis.
+* **Versionamento:** usar Git para rastrear mudanças.
+* **Macros e variáveis:** evitar repetição de código.
+
+---
+
+## Conclusão
+
+Com o dbt, conseguimos **padronizar e automatizar transformações de dados**, trazendo rastreabilidade, escalabilidade e confiança para os pipelines analíticos.
+No contexto do projeto com o IPEA, isso garantiu que cada camada (bronze, silver, gold) tivesse processos bem definidos, organizados e facilmente auditáveis.
+
+


### PR DESCRIPTION
## Documentação DBT

* Explicar o que são **modelos DBT** e como funcionam como unidades de transformação.
* Detalhar a estrutura e a função do arquivo `dbt_project.yml`, incluindo exemplos práticos.
* Elaborar a seção **Referenciando modelos**, mostrando a diferença entre SQL tradicional (subqueries) e dbt (uso do `ref()`), com exemplos bronze → silver → gold.
* Documentar o uso de **sources**, destacando a importância para a camada raw e mostrando como declarar no `schema.yml`.
* Explicar a **Arquitetura Medalhão (Raw, Bronze, Silver, Gold)** no contexto do dbt, incluindo exemplos de queries em cada camada.
* Especificar o que significa um modelo **incremental** e por que é recomendado na camada Bronze.
* Adicionar boas práticas:

  * Nomenclatura clara e consistente
  * Documentação em arquivos `.yml`
  * Testes de qualidade de dados (not\_null, unique, relationships)
  * Separação de pastas por camada (bronze, silver, gold)
* Garantir que todas as seções contenham **exemplos SQL práticos**.
* Avaliar a inclusão de diagramas (lineage e medalhão) para tornar a documentação mais visual.


Closes #33 

