### PR TITLE
Adiciona template de commit

### DIFF
--- a/.github/TEMPLATES/COMMIT_TEMPLATE.md
+++ b/.github/TEMPLATES/COMMIT_TEMPLATE.md
@@ -1,0 +1,68 @@
+# Modelo de Mensagem de Commit (Conventional Commits)
+
+Este documento serve como um guia rápido para a criação de mensagens de commit padronizadas. O uso deste formato é essencial para manter o histórico do projeto legível, facilitar a automação e gerar changelogs de forma automática.
+
+## Estrutura Principal
+
+Cada mensagem de commit consiste em um cabeçalho, um corpo opcional e um rodapé opcional. A estrutura é a seguinte:
+
+```md
+<tipo>[escopo opcional]: <descrição>
+
+[corpo opcional]
+
+[rodapé(s) opcional(is)]
+```
+
+-   **tipo**: Obrigatório. Define a categoria da mudança (ex: `feat`, `fix`, `docs`).
+-   **escopo**: Opcional. Especifica a parte do código que foi alterada (ex: `api`, `parser`, `database`).
+-   **descrição**: Obrigatório. Um resumo conciso da mudança, em letras minúsculas e sem ponto final.
+-   **corpo**: Opcional. Fornece mais contexto, explicando o "porquê" da mudança. Separado da descrição por uma linha em branco.
+-   **rodapé**: Opcional. Usado para referenciar issues (ex: `Refs: #42`) ou para declarar _breaking changes_ (ex: `BREAKING CHANGE:...`).
+
+## Tipos de Commit Recomendados
+
+| Tipo       | Descrição                                                                      |
+| :--------- | :----------------------------------------------------------------------------- |
+| `feat`     | Introduz uma nova funcionalidade ou capacidade.                                |
+| `fix`      | Corrige um bug ou erro no código.                                              |
+| `docs`     | Alterações relacionadas exclusivamente à documentação.                         |
+| `refactor` | Alterações no código que não corrigem um bug nem adicionam uma funcionalidade. |
+| `perf`     | Uma mudança de código que melhora o desempenho.                                |
+| `test`     | Adição ou correção de testes automatizados.                                    |
+| `build`    | Mudanças que afetam o sistema de build ou dependências externas.               |
+| `ci`       | Mudanças nos arquivos e scripts de configuração de Integração Contínua (CI).   |
+| `chore`    | Outras mudanças que não modificam o código-fonte ou os testes.                 |
+| `style`    | Mudanças de estilo de código que não afetam a lógica (formatação, etc.).       |
+
+### Exemplos Práticos
+
+**1. Commit de correção de bug (fix):**
+
+`fix: corrige cálculo de offset na paginação da API`
+
+**2. Commit de nova funcionalidade (feat) com escopo:**
+
+```md
+feat(parser): adiciona suporte para o formato de dados do TSE
+
+Refs: #45
+```
+
+**3. Commit com corpo para mais detalhes:**
+
+```md
+perf(database): otimiza query para busca de metadados
+
+A query anterior utilizava um JOIN desnecessário que causava lentidão
+em datasets com mais de 10.000 registros. Esta mudança simplifica
+a consulta e adiciona um índice na coluna de metadados.
+```
+
+**4. Commit que fecha uma issue do GitHub:**
+
+```md
+fix(ui): resolve problema de renderização de tabelas no Firefox
+
+Closes: #78
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 ## Documentação
 
-Antes de começar, obrigado por considerar contribuir com o **Gov Hub BR**. acreditamos que a colaboração é essencial para construir soluções públicas mais eficientes, transparentes e sustentáveis.
+Antes de começar, obrigado por considerar contribuir com o **Gov Hub BR**. Acreditamos que a colaboração é essencial para construir soluções públicas mais eficientes, transparentes e sustentáveis.
 
-o gov hub br é um projeto open-source com o propósito de transformar dados públicos em ativos estratégicos para a administração pública e a sociedade. toda contribuição, seja código, documentação, ideias ou feedback, é bem-vinda.
+O **Gov Hub BR** é um projeto open-source com o propósito de transformar dados públicos em ativos estratégicos para a administração pública e a sociedade. Toda contribuição, seja código, documentação, ideias ou feedback, é bem-vinda.
 
 ## Como contribuir
 
-1 **faça um fork do repositório**
+### 1. Faça um fork do repositório
 
 Clique em "fork" no canto superior direito da página do projeto e clone o repositório no seu ambiente local:
 
@@ -14,31 +14,30 @@ Clique em "fork" no canto superior direito da página do projeto e clone o repos
 git clone https://github.com/seu-usuario/govhub-br.git
 ```
 
-- crie uma nova branch
+Crie uma nova branch. Recomendamos criar uma branch com um nome descritivo, como ajuste-na-doc ou feature-nova-transformacao:
 
-recomendamos criar uma branch com um nome descritivo, como ajuste-na-doc ou feature-nova-transformacao:
 ```bash
 git checkout -b minha-contribuicao
 ```
 
-2 . **faça suas alterações**
+### 2. faça suas alterações
 
-contribuições podem incluir:
+Contribuições podem incluir:
 
-- melhorias no código ou em pipelines de dados
+-   melhorias no código ou em pipelines de dados
 
-- ajustes ou acréscimos na documentação
+-   ajustes ou acréscimos na documentação
 
-- sugestões de novas funcionalidades
+-   sugestões de novas funcionalidades
 
-- correção de erros ou inconsistências
+-   correção de erros ou inconsistências
 
-lembre-se de seguir as boas práticas de codificação e de escrever mensagens de commit claras e descritivas, neste projeto, utilize o seguinte [modelo de commit](.github/TEMPLATES/COMMIT_TEMPLATE.md). Teste e valide sua contribuição localmente antes de prosseguir.
+Lembre-se de seguir as boas práticas de codificação e de escrever mensagens de commit claras e descritivas, neste projeto, utilize o seguinte [modelo de commit](.github/TEMPLATES/COMMIT_TEMPLATE.md). Teste e valide sua contribuição localmente antes de prosseguir.
 
-3. **sobre o pull request**
+### 3. Sobre o pull request
 
 Antes de enviar, certifique-se de que sua alteração está funcionando corretamente, sem quebrar funcionalidades existentes, e que segue os padrões definidos pelo projeto.
 
-Envie um pull request utilizando o modelo disponível no repositório. isso ajuda a equipe a entender rapidamente o contexto da sua contribuição e agiliza o processo de revisão.
+Envie um pull request utilizando o modelo disponível no repositório. Isso ajuda a equipe a entender rapidamente o contexto da sua contribuição e agiliza o processo de revisão.
 
-Suba sua branch para o seu fork e abra um pull request direcionado ao repositório principal. descreva de forma objetiva o que foi alterado, por que essa mudança é necessária e, sempre que possível, inclua prints, logs ou links relacionados.
+Suba sua branch para o seu fork e abra um pull request direcionado ao repositório principal. Descreva de forma objetiva o que foi alterado, por que essa mudança é necessária e, sempre que possível, inclua prints, logs ou links relacionados.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ contribuições podem incluir:
 
 - correção de erros ou inconsistências
 
-teste e valide sua contribuição
+lembre-se de seguir as boas práticas de codificação e de escrever mensagens de commit claras e descritivas, neste projeto, utilize o seguinte [modelo de commit](.github/TEMPLATES/COMMIT_TEMPLATE.md). Teste e valide sua contribuição localmente antes de prosseguir.
 
 3. **sobre o pull request**
 


### PR DESCRIPTION
Adiciona um novo template de mensagem de commit à documentação do projeto. O modelo fornece diretrizes para escrever mensagens de commit padronizadas usando a especificação **Conventional Commits**, o que ajuda a manter um histórico legível e permite a geração automatizada de _changelogs_.

Melhorias na documentação:

* Adicionado `.github/templates/COMMIT_TEMPLATE.md` com instruções e exemplos para o formato Conventional Commits, incluindo estrutura, tipos recomendados e exemplos práticos.
* Adiciona referência ao padrão de commit em `CONTRIBUTING.md`
* Formatação do guia de contribuição.