### PR TITLE
docs: corrige caminho do cd após clone do repositório

### DIFF
--- a/docs/documentacao/instalacao.md
+++ b/docs/documentacao/instalacao.md
@@ -29,7 +29,7 @@ Para obter o código-fonte do projeto, clone o repositório Git:
 
 ```bash
 git clone https://github.com/GovHub-br/data-application-gov-hub.git
-cd app-lappis-ipea
+cd data-application-gov-hub
 ```
 
 ### 2. Configurando o Ambiente


### PR DESCRIPTION
## Descrição

Este PR corrige o comando de navegação informado na documentação após o clone do repositório.

## Problema

A documentação orientava o uso de:

```bash
git clone https://github.com/GovHub-br/data-application-gov-hub.git
cd app-lappis-ipea
```

<img width="1599" height="858" alt="a9e5b674-5a8c-4fb2-b619-132ff56292b8" src="https://github.com/user-attachments/assets/2f042561-59f7-4e1e-abf3-397fef4c30b6" />

---

No entanto, ao clonar o repositório, o diretório gerado possui o nome `data-application-gov-hub`, o que faz com que o comando `cd app-lappis-ipea` não funcione.

## Solução

Foi ajustado o comando para:

```bash
git clone https://github.com/GovHub-br/data-application-gov-hub.git
cd data-application-gov-hub
```

## Impacto

A alteração evita erro no processo inicial de setup e torna a documentação mais clara para novos contribuidores.