### PR TITLE
docs: adiciona página de sistemas integrados

### DIFF
--- a/docs/sobre-projeto/sistemas-integrados.md
+++ b/docs/sobre-projeto/sistemas-integrados.md
@@ -1,0 +1,21 @@
+# Sistemas Integrados
+
+Esta página apresenta, de forma objetiva, os principais sistemas e bases já utilizados pelo GovHub em seus fluxos de ingestão e análise de dados.
+
+| Sistema | Tipo | Domínio principal | Exemplos de dados | Status |
+| --- | --- | --- | --- | --- |
+| SIAFI | Sistema estruturante | Orçamento e finanças | notas de crédito, empenhos, programação financeira | Ativo |
+| SIAPE | Sistema estruturante | Gestão de pessoas | dados funcionais, dados pessoais, dados financeiros | Ativo |
+| SIORG | Sistema estruturante | Estrutura organizacional | cargos, funções, unidades organizacionais | Ativo |
+| TransfereGov | Sistema estruturante | Transferências e TEDs | programas, planos de ação, notas de crédito | Ativo |
+| Compras.gov.br | Sistema estruturante | Contratos e compras públicas | contratos, faturas, cronogramas, terceirizados | Ativo |
+| PNCP | Base complementar | Contratações públicas | licitações, itens e resultados | Ativo |
+| IBGE | Base complementar | Referência territorial e temática | unidades de conservação e bases auxiliares | Ativo |
+| Dados abertos | Base complementar | Dados legislativos e públicos | deputados, senadores e outras fontes abertas | Ativo |
+| Tesouro Gerencial | Base complementar | Execução orçamentária | dotação, execução, bolsas e empenhos | Ativo |
+
+## Observações
+
+- Os sistemas listados representam as integrações já presentes nos fluxos de ingestão do projeto.
+- O conjunto de fontes pode evoluir conforme novos domínios e novas bases forem incorporados ao GovHub.
+- Esta página complementa a seção [Sistemas Estruturantes](sistemas-estruturantes.md), que apresenta o contexto conceitual dessas integrações.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,6 +175,7 @@ nav:
     - Por que o GovHub: 
       - sobre-projeto/por-que-o-govhub.md
       - Sistemas Estruturantes: sobre-projeto/sistemas-estruturantes.md
+      - Sistemas Integrados: sobre-projeto/sistemas-integrados.md
       - Gestão Orientada a Dados: sobre-projeto/gestao-dados.md
     - Como adotar o GovHub: 
       - sobre-projeto/como-adotar-o-govhub.md


### PR DESCRIPTION
## O que foi alterado

- adiciona a página `Sistemas Integrados`
- inclui a página no menu do portal

## Por que

A página `Sistemas Estruturantes` já explica o contexto conceitual das integrações, mas faltava uma visão prática e objetiva do que já está integrado no GovHub. Esta mudança cria essa visão complementar.

## Testes realizados

- carregamento manual da página no docs
- acesso manual pelo menu
- checagem de regressão da navegação

#104   
